### PR TITLE
Bump ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+        ruby-version: ["3.1", "3.2", "3.3", "3.4", "4.0"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Run tests
-      run: bundle exec rspec
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rspec

--- a/omniauth-swedbank.gemspec
+++ b/omniauth-swedbank.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_runtime_dependency 'omniauth', '~> 2.1'
   spec.add_runtime_dependency 'i18n'


### PR DESCRIPTION
This pull request updates Ruby version support for the project, both in CI and gemspec configuration. The main focus is on dropping support for older Ruby versions and adding compatibility with the latest Ruby releases.

**Ruby version support updates:**

* Updated the GitHub Actions workflow in `.github/workflows/ruby.yml` to test against Ruby versions 3.1, 3.2, 3.3, 3.4, and 4.0, removing support for Ruby 2.7 and 3.0.
* Increased the minimum required Ruby version in `omniauth-swedbank.gemspec` from 2.7 to 3.1.